### PR TITLE
Implement custom client for querying performance limits

### DIFF
--- a/GoodbyeBigSlow/GoodbyeBigSlow.cpp
+++ b/GoodbyeBigSlow/GoodbyeBigSlow.cpp
@@ -10,6 +10,8 @@ OSDefineMetaClassAndStructors(GoodbyeBigSlow, IOService)
 
 #define super IOService
 
+OSDefineMetaClassAndStructors(GoodbyeBigSlowUserClient, IOUserClient)
+
 bool GoodbyeBigSlow::init(OSDictionary* personality)
 {
     DBLogStatus("Initializing", -1);
@@ -46,4 +48,80 @@ void GoodbyeBigSlow::stop(IOService* provider)
 {
     kext_stop(NULL, NULL);
     super::stop(provider);
+}
+
+IOReturn GoodbyeBigSlow::newUserClient(task_t owningTask, void* securityID, UInt32 type, OSDictionary* properties, IOUserClient** handler)
+{
+    GoodbyeBigSlowUserClient* client = new GoodbyeBigSlowUserClient;
+    if (!client) return kIOReturnNoMemory;
+
+    if (!client->initWithTask(owningTask, securityID, type, properties)) {
+        client->release();
+        return kIOReturnError;
+    }
+
+    if (!client->attach(this)) {
+        client->release();
+        return kIOReturnError;
+    }
+
+    if (!client->start(this)) {
+        client->detach(this);
+        client->release();
+        return kIOReturnError;
+    }
+
+    *handler = client;
+    return kIOReturnSuccess;
+}
+
+#undef super
+#define super IOUserClient
+
+bool GoodbyeBigSlowUserClient::initWithTask(task_t owningTask, void* securityID, UInt32 type, OSDictionary* properties)
+{
+    if (!super::initWithTask(owningTask, securityID, type, properties)) return false;
+    fProvider = NULL;
+    return true;
+}
+
+bool GoodbyeBigSlowUserClient::start(IOService* provider)
+{
+    if (!super::start(provider)) return false;
+    fProvider = OSDynamicCast(GoodbyeBigSlow, provider);
+    return fProvider != NULL;
+}
+
+void GoodbyeBigSlowUserClient::stop(IOService* provider)
+{
+    super::stop(provider);
+}
+
+IOReturn GoodbyeBigSlowUserClient::clientClose(void)
+{
+    terminate();
+    return kIOReturnSuccess;
+}
+
+IOReturn GoodbyeBigSlowUserClient::externalMethod(uint32_t selector, IOExternalMethodArguments* arguments, IOExternalMethodDispatch* dispatch, OSObject* target, void* reference)
+{
+    if (selector == 0) { // Read MSR (restricted)
+        if (arguments->scalarInputCount != 1 || arguments->scalarOutputCount != 1) return kIOReturnBadArgument;
+        uint32_t msr = (uint32_t)arguments->scalarInput[0];
+        // Only allow reading specific safe MSRs to avoid GPF/Panic
+        switch (msr) {
+            case 0x198: // MSR_IA32_PERF_STS
+            case 0x199: // MSR_IA32_PERF_CTL
+            case 0x1B1: // MSR_IA32_PACKAGE_THERM_STATUS
+            case 0x19C: // MSR_IA32_THERM_STATUS
+            case 0x1FC: // MSR_IA32_POWER_CTL
+            case 0x1A0: // MSR_IA32_MISC_ENABLE
+            case 0x017: // MSR_IA32_PLATFORM_ID
+                arguments->scalarOutput[0] = rdmsr64(msr);
+                return kIOReturnSuccess;
+            default:
+                return kIOReturnNotPrivileged;
+        }
+    }
+    return kIOReturnUnsupported;
 }

--- a/GoodbyeBigSlow/GoodbyeBigSlow.hpp
+++ b/GoodbyeBigSlow/GoodbyeBigSlow.hpp
@@ -1,4 +1,5 @@
 #include <IOKit/IOService.h>
+#include <IOKit/IOUserClient.h>
 
 class GoodbyeBigSlow : public IOService
 {
@@ -9,4 +10,19 @@ public:
     virtual IOService* probe(IOService* provider, SInt32* score) override;
     virtual bool start(IOService* provider) override;
     virtual void stop(IOService* provider) override;
+    virtual IOReturn newUserClient(task_t owningTask, void* securityID, UInt32 type, OSDictionary* properties, IOUserClient** handler) override;
+};
+
+class GoodbyeBigSlowUserClient : public IOUserClient
+{
+OSDeclareDefaultStructors(GoodbyeBigSlowUserClient)
+public:
+    virtual bool initWithTask(task_t owningTask, void* securityID, UInt32 type, OSDictionary* properties) override;
+    virtual bool start(IOService* provider) override;
+    virtual void stop(IOService* provider) override;
+    virtual IOReturn clientClose(void) override;
+    virtual IOReturn externalMethod(uint32_t selector, IOExternalMethodArguments* arguments, IOExternalMethodDispatch* dispatch, OSObject* target, void* reference) override;
+
+private:
+    GoodbyeBigSlow* fProvider;
 };

--- a/GoodbyeBigSlow/client.c
+++ b/GoodbyeBigSlow/client.c
@@ -1,17 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
 #include <IOKit/IOKitLib.h>
-#include <Kernel/i386/proc_reg.h>
 
 #ifndef MSR_IA32_PERF_STS
 #define MSR_IA32_PERF_STS 0x198
 #endif
-#ifndef MSR_IA32_PERF_CTL
-#define MSR_IA32_PERF_CTL 0x199
-#endif
-#ifndef MSR_IA32_PACKAGE_THERM_STATUS
-#define MSR_IA32_PACKAGE_THERM_STATUS 0x1B1
-#endif
-#ifndef MSR_IA32_POWER_CTL
-#define MSR_IA32_POWER_CTL 0x1FC
-#endif
 
-// TODO: class GoodbyeBigSlowClient : public IOUserClient
+uint64_t read_msr(io_connect_t connect, uint32_t msr) {
+    uint64_t input = msr;
+    uint64_t output = 0;
+    uint32_t output_count = 1;
+    kern_return_t kr = IOConnectCallScalarMethod(connect, 0, &input, 1, &output, &output_count);
+    if (kr != KERN_SUCCESS) {
+        return 0;
+    }
+    return output;
+}
+
+int main() {
+    io_service_t service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("GoodbyeBigSlow"));
+    if (!service) {
+        // If kext is not loaded, we just exit silently or with error.
+        // The script will fall back to sysctl if it handles it.
+        return 1;
+    }
+
+    io_connect_t connect;
+    kern_return_t kr = IOServiceOpen(service, mach_task_self(), 0, &connect);
+    IOObjectRelease(service);
+    if (kr != KERN_SUCCESS) {
+        return 1;
+    }
+
+    uint64_t perf_sts = read_msr(connect, MSR_IA32_PERF_STS);
+
+    // Output with "PLIMIT" in the key so it's not filtered out by the script's sed.
+    printf("machdep.goodbyebigslow.PLIMIT_msr_perf_sts=%llu\n", perf_sts);
+
+    IOServiceClose(connect);
+    return 0;
+}

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ CODE_SIGN_IDENTITY := -
 # $ nm /System/Library/Kernels/kernel | less
 # $ otool -xV /System/Library/Kernels/kernel | less
 # $ kextfind -rsym _pmCPUControl
-all: $(KEXT_BIN)
+all: $(KEXT_BIN) GoodbyeBigSlowClient
+
+GoodbyeBigSlowClient: GoodbyeBigSlow/client.c
+	$(CC) $(CFLAGS) -Wall -Wextra -O3 -o $@ $< -framework IOKit -framework CoreFoundation
 
 $(KEXT_BIN): $(KEXT_DEPS) # $(PLUGIN_DIR)
 ifeq ($(XCODE),ON)
@@ -81,6 +84,6 @@ unload:
 	sudo kextunload -v 4 -b $(KEXT_ID)
 
 clean:
-	rm -v -R -f build
+	rm -v -R -f build GoodbyeBigSlowClient
 
 .PHONEY: all install uninstall clean

--- a/other/show_plimits.sh
+++ b/other/show_plimits.sh
@@ -12,13 +12,19 @@ echo() {
   printf '%s\n' "$*"
 }
 
-# TODO: query using GoodbyeBigSlowClient instead
-sysctl -A -e \
-  | sed -e '/^[^=]*[Pp][Ll][Ii][Mm][Ii][Tt]/ b p' \
+script_dir="$(dirname -- "$0")"
+
+# Use GoodbyeBigSlowClient for querying PLimits and performance status
+{
+  if [ -x "${script_dir}/../GoodbyeBigSlowClient" ]; then
+    "${script_dir}/../GoodbyeBigSlowClient" || true
+  elif command -v GoodbyeBigSlowClient >/dev/null 2>&1; then
+    GoodbyeBigSlowClient || true
+  fi
+  sysctl -A -e
+} | sed -e '/^[^=]*[Pp][Ll][Ii][Mm][Ii][Tt]/ b p' \
         -e '/^hw.busfrequency=/ b p' \
         -e d -e ':p' -e 's/=/ = /'
-
-script_dir="$(dirname -- "$0")"
 
 xslt() {
   xsltproc --nonet --novalid --path "${script_dir}" ${1+"$@"}


### PR DESCRIPTION
This change implements the custom client communication for GoodbyeBigSlow, allowing user-space tools to query the kernel extension's status. It includes a safe kernel interface for reading specific MSRs and updates the existing `show_plimits.sh` script to leverage this new capability.

---
*PR created automatically by Jules for task [7808957065233856161](https://jules.google.com/task/7808957065233856161) started by @Mouhamedn*