### PR TITLE
Add X86PlatformShim to Xcode project

### DIFF
--- a/GoodbyeBigSlow.xcodeproj/project.pbxproj
+++ b/GoodbyeBigSlow.xcodeproj/project.pbxproj
@@ -7,15 +7,54 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3D63F6A927AF94190089B0B6 /* X86PlatformShim.kext in PlugIns */ = {isa = PBXBuildFile; fileRef = 3D63F6A027AF94190089B0B6 /* X86PlatformShim.kext */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3D63F69627AF94190089B0B6 /* GoodbyeBigSlow.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D63F69527AF94190089B0B6 /* GoodbyeBigSlow.hpp */; };
 		3D63F69827AF94190089B0B6 /* GoodbyeBigSlow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D63F69727AF94190089B0B6 /* GoodbyeBigSlow.cpp */; };
+		3D63F6AA27AF94190089B0B6 /* X86PlatformShim.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3D63F6A127AF94190089B0B6 /* X86PlatformShim.plist */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3D63F6A727AF94190089B0B6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3D63F68927AF94190089B0B6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3D63F6A327AF94190089B0B6;
+			remoteInfo = X86PlatformShim;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3D63F6A227AF94190089B0B6 /* PlugIns */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				3D63F6A927AF94190089B0B6 /* X86PlatformShim.kext in PlugIns */,
+			);
+			name = PlugIns;
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3D63F6AB27AF94190089B0B6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3D63F6AA27AF94190089B0B6 /* X86PlatformShim.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		3D63F69227AF94190089B0B6 /* GoodbyeBigSlow.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoodbyeBigSlow.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D63F69527AF94190089B0B6 /* GoodbyeBigSlow.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = GoodbyeBigSlow.hpp; sourceTree = "<group>"; };
 		3D63F69727AF94190089B0B6 /* GoodbyeBigSlow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GoodbyeBigSlow.cpp; sourceTree = "<group>"; };
 		3D63F69927AF94190089B0B6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3D63F6A027AF94190089B0B6 /* X86PlatformShim.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = X86PlatformShim.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D63F6A127AF94190089B0B6 /* X86PlatformShim.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = X86PlatformShim.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -41,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				3D63F69227AF94190089B0B6 /* GoodbyeBigSlow.kext */,
+				3D63F6A027AF94190089B0B6 /* X86PlatformShim.kext */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -51,6 +91,7 @@
 				3D63F69527AF94190089B0B6 /* GoodbyeBigSlow.hpp */,
 				3D63F69727AF94190089B0B6 /* GoodbyeBigSlow.cpp */,
 				3D63F69927AF94190089B0B6 /* Info.plist */,
+				3D63F6A127AF94190089B0B6 /* X86PlatformShim.plist */,
 			);
 			path = GoodbyeBigSlow;
 			sourceTree = "<group>";
@@ -77,17 +118,42 @@
 				3D63F68E27AF94190089B0B6 /* Sources */,
 				3D63F68F27AF94190089B0B6 /* Frameworks */,
 				3D63F69027AF94190089B0B6 /* Resources */,
+				3D63F6A227AF94190089B0B6 /* PlugIns */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				3D63F6A827AF94190089B0B6 /* PBXTargetDependency */,
 			);
 			name = GoodbyeBigSlow;
 			productName = GoodbyeBigSlow;
 			productReference = 3D63F69227AF94190089B0B6 /* GoodbyeBigSlow.kext */;
 			productType = "com.apple.product-type.kernel-extension";
 		};
+		3D63F6A327AF94190089B0B6 /* X86PlatformShim */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3D63F6A427AF94190089B0B6 /* Build configuration list for PBXNativeTarget "X86PlatformShim" */;
+			buildPhases = (
+				3D63F6AB27AF94190089B0B6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = X86PlatformShim;
+			productName = X86PlatformShim;
+			productReference = 3D63F6A027AF94190089B0B6 /* X86PlatformShim.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
 /* End PBXNativeTarget section */
+
+/* Begin PBXTargetDependency section */
+		3D63F6A827AF94190089B0B6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3D63F6A327AF94190089B0B6 /* X86PlatformShim */;
+			targetProxy = 3D63F6A727AF94190089B0B6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXProject section */
 		3D63F68927AF94190089B0B6 /* Project object */ = {
@@ -115,6 +181,7 @@
 			projectRoot = "";
 			targets = (
 				3D63F69127AF94190089B0B6 /* GoodbyeBigSlow */,
+				3D63F6A327AF94190089B0B6 /* X86PlatformShim */,
 			);
 		};
 /* End PBXProject section */
@@ -292,6 +359,36 @@
 			};
 			name = Release;
 		};
+		3D63F6A527AF94190089B0B6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = GoodbyeBigSlow/X86PlatformShim.plist;
+				MARKETING_VERSION = 2022.3.31;
+				PRODUCT_BUNDLE_IDENTIFIER = jakwings.kext.GoodbyeBigSlow;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		3D63F6A627AF94190089B0B6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = GoodbyeBigSlow/X86PlatformShim.plist;
+				MARKETING_VERSION = 2022.3.31;
+				PRODUCT_BUNDLE_IDENTIFIER = jakwings.kext.GoodbyeBigSlow;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -309,6 +406,15 @@
 			buildConfigurations = (
 				3D63F69D27AF94190089B0B6 /* Debug */,
 				3D63F69E27AF94190089B0B6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3D63F6A427AF94190089B0B6 /* Build configuration list for PBXNativeTarget "X86PlatformShim" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3D63F6A527AF94190089B0B6 /* Debug */,
+				3D63F6A627AF94190089B0B6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/GoodbyeBigSlow/GoodbyeBigSlow.cpp
+++ b/GoodbyeBigSlow/GoodbyeBigSlow.cpp
@@ -7,6 +7,7 @@
 #include "GoodbyeBigSlow.hpp"
 
 OSDefineMetaClassAndStructors(GoodbyeBigSlow, IOService)
+OSDefineMetaClassAndStructors(GoodbyeBigSlow_NoHardPLimits, GoodbyeBigSlow)
 
 #define super IOService
 

--- a/GoodbyeBigSlow/GoodbyeBigSlow.hpp
+++ b/GoodbyeBigSlow/GoodbyeBigSlow.hpp
@@ -10,3 +10,8 @@ public:
     virtual bool start(IOService* provider) override;
     virtual void stop(IOService* provider) override;
 };
+
+class GoodbyeBigSlow_NoHardPLimits : public GoodbyeBigSlow
+{
+OSDeclareDefaultStructors(GoodbyeBigSlow_NoHardPLimits)
+};

--- a/Makefile
+++ b/Makefile
@@ -44,17 +44,17 @@ CODE_SIGN_IDENTITY := -
 # $ kextfind -rsym _pmCPUControl
 all: $(KEXT_BIN)
 
-$(KEXT_BIN): $(KEXT_DEPS) # $(PLUGIN_DIR)
 ifeq ($(XCODE),ON)
+$(KEXT_BIN): $(KEXT_DEPS)
 	xcodebuild -verbose -project $(PROJ) -target GoodbyeBigSlow -configuration Release MARKETING_VERSION=$(KEXT_VERSION) PRODUCT_BUNDLE_IDENTIFIER=$(KEXT_ID) MODULE_NAME=$(KEXT_ID) MODULE_VERSION=$(KEXT_VERSION) MACOSX_DEPLOYMENT_TARGET=$(MACOS_VERSION_MIN) CODE_SIGN_IDENTITY="-"
 else
+$(KEXT_BIN): $(KEXT_DEPS) $(PLUGIN_DIR)
 	mkdir -p $(KEXT_DIR)/Contents/MacOS
 	sed -e 's/\$$(PRODUCT_BUNDLE_IDENTIFIER)/$(KEXT_ID)/g' -e 's/\$$(MARKETING_VERSION)/$(KEXT_VERSION)/g' -e 's/\$$(MACOSX_DEPLOYMENT_TARGET)/$(MACOS_VERSION_MIN)/g' <$(NAME)/Info.plist >$(KEXT_DIR)/Contents/Info.plist
 	$(CXX) $(CFLAGS) $(CPPFLAGS) -DXCODE_OFF -DKEXT_ID=$(KEXT_ID) -DKEXT_VERSION=$(KEXT_VERSION) -nostdinc -std=c++11 -stdlib=libc++ -Os -fno-builtin -fno-exceptions -fno-rtti -fno-common -mkernel -fapple-kext -fasm-blocks -fstrict-aliasing -DKERNEL -DKERNEL_PRIVATE -DDRIVER_PRIVATE -DAPPLE -DNeXT -isystem "$(shell xcrun --sdk macosx --show-sdk-path)/System/Library/Frameworks/Kernel.framework/Headers" -mmacosx-version-min=$(MACOS_VERSION_MIN) -static $(NAME)/$(NAME).cpp -o $(KEXT_BIN) -Xlinker -kext -nostdlib -lkmodc++ -lkmod -lcc_kext -pedantic -Wall -Wextra -Wno-extra-semi
 endif
 	xcrun codesign --force --deep --sign "$(CODE_SIGN_IDENTITY)" --entitlements $(NAME)/entitlements.xml --timestamp=none $(KEXT_DIR)
 
-# TODO: add to GoodbyeBigSlow.xcodeproj ?
 $(PLUGIN_DIR): $(PLUGIN_DEPS)
 	mkdir -p $(PLUGIN_DIR)/Contents
 	sed -e 's/\$$(PRODUCT_BUNDLE_IDENTIFIER)/$(KEXT_ID)/g' -e 's/\$$(MARKETING_VERSION)/$(KEXT_VERSION)/g' -e 's/\$$(MACOSX_DEPLOYMENT_TARGET)/$(MACOS_VERSION_MIN)/g' <$(NAME)/X86PlatformShim.plist >$(PLUGIN_DIR)/Contents/Info.plist


### PR DESCRIPTION
This change integrates the X86PlatformShim.kext plugin into the Xcode project. It establishes a proper target dependency and a "PlugIns" copy phase so that the shim is automatically built and bundled inside the main GoodbyeBigSlow.kext. The GoodbyeBigSlow_NoHardPLimits class, required by the shim's personality, has also been implemented in the main C++ source files. The Makefile was updated to align with these changes and avoid redundant build steps when XCODE=ON.

---
*PR created automatically by Jules for task [3703839364310351411](https://jules.google.com/task/3703839364310351411) started by @Mouhamedn*