### PR TITLE
🧪 [testing] Add unit tests for flag-parsing logic

### DIFF
--- a/GoodbyeBigSlow/tests/mock/IOKit/IOLib.h
+++ b/GoodbyeBigSlow/tests/mock/IOKit/IOLib.h
@@ -1,0 +1,24 @@
+#ifndef IOKIT_IOLIB_H
+#define IOKIT_IOLIB_H
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+static void IOLog(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+}
+
+static void IOSleep(uint32_t milliseconds) {
+    // Dummy
+}
+
+static bool PE_parse_boot_argn(const char *argName, void *argPtr, int argSize) {
+    return false;
+}
+
+#endif

--- a/GoodbyeBigSlow/tests/mock/i386/cpuid.h
+++ b/GoodbyeBigSlow/tests/mock/i386/cpuid.h
@@ -1,0 +1,17 @@
+#ifndef I386_CPUID_H
+#define I386_CPUID_H
+
+#include <stdint.h>
+
+enum {
+    eax = 0,
+    ebx = 1,
+    ecx = 2,
+    edx = 3
+};
+
+static void cpuid(uint32_t *regs) {
+    // Dummy implementation
+}
+
+#endif

--- a/GoodbyeBigSlow/tests/mock/i386/proc_reg.h
+++ b/GoodbyeBigSlow/tests/mock/i386/proc_reg.h
@@ -1,0 +1,9 @@
+#ifndef I386_PROC_REG_H
+#define I386_PROC_REG_H
+
+#include <stdint.h>
+
+static uint64_t rdmsr64(uint32_t msr) { return 0; }
+static void wrmsr64(uint32_t msr, uint64_t val) {}
+
+#endif

--- a/GoodbyeBigSlow/tests/mock/libkern/libkern.h
+++ b/GoodbyeBigSlow/tests/mock/libkern/libkern.h
@@ -1,0 +1,23 @@
+#ifndef LIBKERN_LIBKERN_H
+#define LIBKERN_LIBKERN_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+
+typedef int32_t kern_return_t;
+#define KERN_SUCCESS 0
+#define KERN_FAILURE 1
+
+#ifndef __unused
+#define __unused __attribute__((unused))
+#endif
+
+typedef int64_t SInt64;
+
+static void OSIncrementAtomic64(volatile SInt64 *var) {
+    __sync_fetch_and_add(var, 1);
+}
+
+#endif

--- a/GoodbyeBigSlow/tests/mock/mach/mach_types.h
+++ b/GoodbyeBigSlow/tests/mock/mach/mach_types.h
@@ -1,0 +1,12 @@
+#ifndef MACH_MACH_TYPES_H
+#define MACH_MACH_TYPES_H
+
+#include <stdint.h>
+
+typedef struct kmod_info {
+    // Dummy structure
+} kmod_info_t;
+
+typedef int32_t kern_return_t;
+
+#endif

--- a/GoodbyeBigSlow/tests/mock/sys/ioccom.h
+++ b/GoodbyeBigSlow/tests/mock/sys/ioccom.h
@@ -1,0 +1,4 @@
+#ifndef SYS_IOCCOM_H
+#define SYS_IOCCOM_H
+// Empty mock
+#endif

--- a/GoodbyeBigSlow/tests/test_flags.c
+++ b/GoodbyeBigSlow/tests/test_flags.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+// Mock kernel functions and include the source file
+#define static
+// We need to provide these before including the source if they are extern there
+void mp_rendezvous_no_intrs(void (*func)(void *), void *arg) {}
+#include "../GoodbyeBigSlow.c"
+#undef static
+
+void test_eql_flag() {
+    printf("Testing eql_flag...\n");
+    assert(eql_flag("-turbo", "-turbo", 6));
+    assert(eql_flag("-speedstep", "-speedstep", 10));
+    assert(!eql_flag("-turbo", "-speedstep", 6));
+    assert(!eql_flag("-turbo", "-turb", 6));
+    assert(eql_flag("-turbo:other", "-turbo", 6));
+    assert(!eql_flag("turbo", "-turbo", 6));
+    printf("eql_flag tests passed!\n");
+}
+
+void test_has_flag() {
+    printf("Testing has_flag...\n");
+
+    // Single flag
+    assert(has_flag("-turbo", "-turbo"));
+    assert(!has_flag("-speedstep", "-turbo"));
+
+    // Multiple flags
+    assert(has_flag("-turbo:-speedstep", "-turbo"));
+    assert(has_flag("-turbo:-speedstep", "-speedstep"));
+
+    // Flag at the end
+    assert(has_flag("other:-turbo", "-turbo"));
+
+    // Flag in the middle
+    assert(has_flag("a:-turbo:b", "-turbo"));
+
+    // Edge cases
+    assert(!has_flag("-turbos", "-turbo"));
+    assert(!has_flag("not-turbo", "-turbo"));
+    assert(!has_flag("-turbo", "turbo")); // has_flag expects '-' or '+' at start of arg
+
+    // Colons
+    assert(has_flag(":-turbo:", "-turbo"));
+
+    printf("has_flag tests passed!\n");
+}
+
+int main() {
+    test_eql_flag();
+    test_has_flag();
+    printf("All tests passed successfully!\n");
+    return 0;
+}

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ load:
 unload:
 	sudo kextunload -v 4 -b $(KEXT_ID)
 
+test:
+	$(CC) -I GoodbyeBigSlow/tests/mock -I GoodbyeBigSlow/ GoodbyeBigSlow/tests/test_flags.c -o GoodbyeBigSlow/tests/test_flags
+	./GoodbyeBigSlow/tests/test_flags
+	rm GoodbyeBigSlow/tests/test_flags
+
 clean:
 	rm -v -R -f build
 


### PR DESCRIPTION
This PR introduces a testing suite to the `GoodbyeBigSlow` repository to improve reliability and coverage.

### 🎯 What:
Addressed the missing test files by creating a dedicated testing environment for kernel logic that can be executed in userspace.

### 📊 Coverage:
The following scenarios for `has_flag` and `eql_flag` are now tested:
- Single flag matching
- Multiple colon-separated flags
- Flags at the start, middle, or end of the string
- Edge cases like substring matches (e.g., `-turbos` vs `-turbo`)
- Proper handling of colons as delimiters

### ✨ Result:
- Introduced a repeatable test process via `make test`.
- Enabled cross-platform verification of core logic on Linux using mock headers.
- Established a foundation for future testing of non-hardware-dependent kernel code.

---
*PR created automatically by Jules for task [8259877998917898238](https://jules.google.com/task/8259877998917898238) started by @Mouhamedn*