### PR TITLE
Improve MSR modification safety and verify Turbo Boost disabling via CPUID

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Reuse cached files
         uses: actions/cache@v3

--- a/GoodbyeBigSlow/GoodbyeBigSlow.c
+++ b/GoodbyeBigSlow/GoodbyeBigSlow.c
@@ -64,7 +64,7 @@ static void mp_deassert_prochot(void *data)
     // hopefully not to cause invalid write and the black screen of death
     if (old_bits != new_bits) {
         wrmsr64(MSR_IA32_POWER_CTL, new_bits);
-        IOSleep(1);
+        IODelay(1000);
         if (!(rdmsr64(MSR_IA32_POWER_CTL) & kMsrEnableProcHot)) {
             OSIncrementAtomic64(VOLATILE_ACCESS(disabled));
         }
@@ -119,8 +119,10 @@ static bool deassert_prochot(void)
     return false;
 }
 
-static bool disable_turbo(void)
+static void mp_disable_turbo(void *data)
 {
+    SInt64 *cpucount = (SInt64 *)data;
+    SInt64 *disabled = (SInt64 *)data + 1;
     uint32_t registers[4] = {[eax]=6, [ebx]=0, [ecx]=0, [edx]=0};
     cpuid(registers);
 
@@ -129,17 +131,40 @@ static bool disable_turbo(void)
         uint64_t new_bits = old_bits | kMsrDisableTurboBoost;
 
         if (old_bits != new_bits) {
-            // XXX: CPUID.06H:EAX[1] => 0
             wrmsr64(MSR_IA32_MISC_ENABLE, new_bits);
-            IOSleep(1);
-            return rdmsr64(MSR_IA32_MISC_ENABLE) & kMsrDisableTurboBoost;
+            IODelay(1000);
+
+            registers[eax] = 6;
+            registers[ebx] = 0;
+            registers[ecx] = 0;
+            registers[edx] = 0;
+            cpuid(registers);
+
+            if (!(registers[eax] & (1 << 1))) {
+                OSIncrementAtomic64(VOLATILE_ACCESS(disabled));
+            }
+        } else {
+            OSIncrementAtomic64(VOLATILE_ACCESS(disabled));
         }
+    } else {
+        OSIncrementAtomic64(VOLATILE_ACCESS(disabled));
     }
-    return true;
+    OSIncrementAtomic64(VOLATILE_ACCESS(cpucount));
 }
 
-static bool disable_speedstep(void)
+static bool disable_turbo(void)
 {
+    SInt64 counts[2] __attribute__((aligned(sizeof(SInt64)))) = {0, 0};
+
+    mp_rendezvous_no_intrs(mp_disable_turbo, counts);
+
+    return counts[0] == counts[1];
+}
+
+static void mp_disable_speedstep(void *data)
+{
+    SInt64 *cpucount = (SInt64 *)data;
+    SInt64 *disabled = (SInt64 *)data + 1;
     uint32_t registers[4] = {[eax]=1, [ebx]=0, [ecx]=0, [edx]=0};
     cpuid(registers);
 
@@ -149,11 +174,26 @@ static bool disable_speedstep(void)
 
         if (old_bits != new_bits) {
             wrmsr64(MSR_IA32_MISC_ENABLE, new_bits);
-            IOSleep(1);
-            return !(rdmsr64(MSR_IA32_MISC_ENABLE) & kMsrEnableSpeedStep);
+            IODelay(1000);
+            if (!(rdmsr64(MSR_IA32_MISC_ENABLE) & kMsrEnableSpeedStep)) {
+                OSIncrementAtomic64(VOLATILE_ACCESS(disabled));
+            }
+        } else {
+            OSIncrementAtomic64(VOLATILE_ACCESS(disabled));
         }
+    } else {
+        OSIncrementAtomic64(VOLATILE_ACCESS(disabled));
     }
-    return true;
+    OSIncrementAtomic64(VOLATILE_ACCESS(cpucount));
+}
+
+static bool disable_speedstep(void)
+{
+    SInt64 counts[2] __attribute__((aligned(sizeof(SInt64)))) = {0, 0};
+
+    mp_rendezvous_no_intrs(mp_disable_speedstep, counts);
+
+    return counts[0] == counts[1];
 }
 
 static bool eql_flag(const char *a, const char *b, size_t n)

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ all: $(KEXT_BIN)
 
 $(KEXT_BIN): $(KEXT_DEPS) # $(PLUGIN_DIR)
 ifeq ($(XCODE),ON)
-	xcodebuild -verbose -project $(PROJ) -target GoodbyeBigSlow -configuration Release MARKETING_VERSION=$(KEXT_VERSION) PRODUCT_BUNDLE_IDENTIFIER=$(KEXT_ID) MODULE_NAME=$(KEXT_ID) MODULE_VERSION=$(KEXT_VERSION) MACOSX_DEPLOYMENT_TARGET=$(MACOS_VERSION_MIN) CODE_SIGN_IDENTITY="-"
+	xcodebuild -verbose -project $(PROJ) -target GoodbyeBigSlow -configuration Release MARKETING_VERSION=$(KEXT_VERSION) PRODUCT_BUNDLE_IDENTIFIER=$(KEXT_ID) MODULE_NAME=$(KEXT_ID) MODULE_VERSION=$(KEXT_VERSION) MACOSX_DEPLOYMENT_TARGET=$(MACOS_VERSION_MIN) CODE_SIGN_IDENTITY="-" ARCHS=x86_64
 else
 	mkdir -p $(KEXT_DIR)/Contents/MacOS
 	sed -e 's/\$$(PRODUCT_BUNDLE_IDENTIFIER)/$(KEXT_ID)/g' -e 's/\$$(MARKETING_VERSION)/$(KEXT_VERSION)/g' -e 's/\$$(MACOSX_DEPLOYMENT_TARGET)/$(MACOS_VERSION_MIN)/g' <$(NAME)/Info.plist >$(KEXT_DIR)/Contents/Info.plist
-	$(CXX) $(CFLAGS) $(CPPFLAGS) -DXCODE_OFF -DKEXT_ID=$(KEXT_ID) -DKEXT_VERSION=$(KEXT_VERSION) -nostdinc -std=c++11 -stdlib=libc++ -Os -fno-builtin -fno-exceptions -fno-rtti -fno-common -mkernel -fapple-kext -fasm-blocks -fstrict-aliasing -DKERNEL -DKERNEL_PRIVATE -DDRIVER_PRIVATE -DAPPLE -DNeXT -isystem "$(shell xcrun --sdk macosx --show-sdk-path)/System/Library/Frameworks/Kernel.framework/Headers" -mmacosx-version-min=$(MACOS_VERSION_MIN) -static $(NAME)/$(NAME).cpp -o $(KEXT_BIN) -Xlinker -kext -nostdlib -lkmodc++ -lkmod -lcc_kext -pedantic -Wall -Wextra -Wno-extra-semi
+	$(CXX) $(CFLAGS) $(CPPFLAGS) -arch x86_64 -DXCODE_OFF -DKEXT_ID=$(KEXT_ID) -DKEXT_VERSION=$(KEXT_VERSION) -nostdinc -std=c++11 -stdlib=libc++ -Os -fno-builtin -fno-exceptions -fno-rtti -fno-common -mkernel -fapple-kext -fasm-blocks -fstrict-aliasing -DKERNEL -DKERNEL_PRIVATE -DDRIVER_PRIVATE -DAPPLE -DNeXT -isystem "$(shell xcrun --sdk macosx --show-sdk-path)/System/Library/Frameworks/Kernel.framework/Headers" -mmacosx-version-min=$(MACOS_VERSION_MIN) -static $(NAME)/$(NAME).cpp -o $(KEXT_BIN) -Xlinker -kext -nostdlib -lkmodc++ -lkmod -lcc_kext -pedantic -Wall -Wextra -Wno-extra-semi
 endif
 	xcrun codesign --force --deep --sign "$(CODE_SIGN_IDENTITY)" --entitlements $(NAME)/entitlements.xml --timestamp=none $(KEXT_DIR)
 


### PR DESCRIPTION
This change improves the reliability and safety of the `GoodbyeBigSlow` kernel extension by ensuring that MSR modifications (Turbo Boost and SpeedStep) are applied to all CPU cores and verified using both MSR reads and CPUID status bits. It also fixes a critical bug where `IOSleep` (a blocking call) was used within an interrupt-disabled rendezvous context, which is prohibited in macOS kernel development. The new implementation uses `IODelay` for short busy-waits and `mp_rendezvous_no_intrs` for synchronized multi-processor execution.

---
*PR created automatically by Jules for task [17619010702073698606](https://jules.google.com/task/17619010702073698606) started by @Mouhamedn*